### PR TITLE
Initialize last battery update time with 0

### DIFF
--- a/ocean_battery_driver/src/ocean_battery_driver/ocean.cpp
+++ b/ocean_battery_driver/src/ocean_battery_driver/ocean.cpp
@@ -75,9 +75,9 @@ ocean::ocean ( int id,  int debug)
   server.id = id;
   server.battery.resize(4);
 
-  // Mark last update as "-1" for initial values
+  // Mark last update as time "0" for initial values
   for (uint i = 0; i < server.battery.size(); ++i)
-    server.battery[i].last_battery_update = ros::Time(-1);
+    server.battery[i].last_battery_update = ros::Time(0);
 }
 
 ocean::~ocean ()


### PR DESCRIPTION
In kinetic initializing a ros time with -1 throws the following error:
"Time is out of dual 32-bit range"

Change it to time(0) keeps the previous behaviour, but uses time 0 as initial value.