### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/pr2_power_board/package.xml
+++ b/pr2_power_board/package.xml
@@ -12,6 +12,8 @@
   <author>Blaise Gassend</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>

--- a/pr2_power_board/package.xml
+++ b/pr2_power_board/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>pr2_power_board</name>
   <version>1.1.10</version>
   <description>This provides a ROS node for the PR2 Power Board.</description>
@@ -21,11 +21,11 @@
   <build_depend>log4cxx</build_depend>
   <build_depend>libboost-program-options-dev</build_depend>
 
-  <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>diagnostic_updater</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>pr2_msgs</run_depend>
-  <run_depend>log4cxx</run_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>diagnostic_updater</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>pr2_msgs</exec_depend>
+  <exec_depend>log4cxx</exec_depend>
 </package>

--- a/pr2_power_board/setup.py
+++ b/pr2_power_board/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup_args = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.